### PR TITLE
Fixing build error on MSVC compiler.

### DIFF
--- a/headers/ewahutil.h
+++ b/headers/ewahutil.h
@@ -193,7 +193,7 @@ inline uint32_t countOnes(uint64_t x) {
     return static_cast<uint32_t>(__builtin_popcountl(x));
 }
 #elif defined(_MSC_VER) && _MSC_VER >= 1400
-inline uint32_t countOnes(uint32_t x) {
+inline uint32_t countOnes(uint64_t x) {
 	return static_cast<uint32_t>(__popcnt64(static_cast<__int64>(x)));
 }
 #else


### PR DESCRIPTION
Root Cause:
Function countOnes was using uint32_t instead of uint64_t for the 64 bit integer. This caused the following build error on MSVC:
error C2084: function 'uint32_t countOnes(uint32_t)' already has a body

Corrective Action:
Changed the param type to uint64_t
