### PR TITLE
fix underflow bug during logical negation

### DIFF
--- a/headers/ewah.h
+++ b/headers/ewah.h
@@ -908,11 +908,8 @@ template <class uword> void EWAHBoolArray<uword>::inplace_logicalnot() {
         (static_cast<uword>(1) << (sizeinbits % wordinbits)) - 1;
     if (rlw.getNumberOfLiteralWords() > 0) { // easy case
       buffer[lastrlw + 1 + rlw.getNumberOfLiteralWords() - 1] &= maskbogus;
-    } else if (rlw.getRunningBit()) {
-#ifdef EWAHASSERT
-      assert(rlw.getNumberOfLiteralWords() > 0);
-#endif
-      rlw.setNumberOfLiteralWords(rlw.getNumberOfLiteralWords() - 1);
+    } else {
+      rlw.setRunningLength(rlw.getRunningLength() - 1);
       addLiteralWord(maskbogus);
     }
   }


### PR DESCRIPTION
Underflow occurred when literal word count was 0, resulting in later crashes if vector was used as a logic operand during logic operations. Please advise as to valid solution; the proposed solution below works as far as I've tested it. Thanks.